### PR TITLE
Update LocationForecast

### DIFF
--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -6,7 +6,7 @@ class ForecastFacade
   end
 
   def location_forecast
-    @location_forecast ||= LocationForecast.new(forecast)
+    @location_forecast ||= LocationForecast.new(location_address, forecast)
   end
 
   def background_images
@@ -22,11 +22,11 @@ class ForecastFacade
   end
 
   def flickr_lat
-    latlong[:lat].to_s
+    location_latlong[:lat].to_s
   end
 
   def flickr_long
-    latlong[:lng].to_s
+    location_latlong[:lng].to_s
   end
 
   def forecast
@@ -38,11 +38,19 @@ class ForecastFacade
   end
 
   def darksky_latlong
-    latlong[:lat].to_s + ',' + latlong[:lng].to_s
+    location_latlong[:lat].to_s + ',' + location_latlong[:lng].to_s
   end
 
-  def latlong
-    @latlong ||= google_maps_service.retrieve_latlong(location_params)
+  def location_latlong
+    location_info[:geometry][:location]
+  end
+
+  def location_address
+    location_info[:formatted_address]
+  end
+
+  def location_info
+    @location_info ||= google_maps_service.retrieve_location_info(location_params)
   end
 
   def google_maps_service

--- a/app/models/location_forecast.rb
+++ b/app/models/location_forecast.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class LocationForecast
-  attr_reader :currently, :hourly, :daily
+  attr_reader :location_address, :currently, :hourly, :daily
 
-  def initialize(forecast)
+  def initialize(location_address, forecast)
+    @location_address = location_address
     @currently = forecast[:currently]
     @hourly = forecast[:hourly][:data]
     @daily = forecast[:daily][:data]

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -2,6 +2,7 @@ class ForecastSerializer
   def self.serialize(location_forecast)
     {
       data: {
+        location: location_forecast.location_address,
         currently: {
           date: Time.at(location_forecast.currently[:time]).to_datetime.strftime('%m-%d'),
           time: Time.at(location_forecast.currently[:time]).to_datetime.strftime('%I:%M%p'),

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class GoogleMapsService
-  def retrieve_latlong(location)
-    parse_response('geocode/json', address: location)[:results][0][:geometry][:location]
+  def retrieve_location_info(location)
+    parse_response('geocode/json', address: location)[:results][0]
   end
 
   private

--- a/spec/models/location_forecast_spec.rb
+++ b/spec/models/location_forecast_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LocationForecast do
     forecast_data = File.read('./spec/fixtures/darksky_location_forecast.json')
     forecast = JSON.parse(forecast_data, symbolize_names: true)
 
-    @location_forecast = LocationForecast.new(forecast)
+    @location_forecast = LocationForecast.new('Denver, CO, USA', forecast)
   end
 
   it 'exists' do
@@ -15,6 +15,10 @@ RSpec.describe LocationForecast do
   end
 
   describe 'instance methods' do
+    it '#location_address' do
+      expect(@location_forecast.location_address).to eq('Denver, CO, USA')
+    end
+
     it '#currently' do
       expect(@location_forecast.currently).to be_a(Hash)
     end

--- a/spec/requests/api/v1/forecast_request_spec.rb
+++ b/spec/requests/api/v1/forecast_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Forecast API endpoint' do
 
     forecast = JSON.parse(response.body, symbolize_names: true)[:data]
 
+    expect(forecast).to have_key(:location)
     expect(forecast).to have_key(:currently)
     expect(forecast).to have_key(:hourly)
     expect(forecast).to have_key(:daily)

--- a/spec/services/google_maps_service_spec.rb
+++ b/spec/services/google_maps_service_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 
 RSpec.describe GoogleMapsService do
   describe 'instance methods' do
-    it '#retrieve_latlong' do
-      response = subject.retrieve_latlong('denver,co')
+    it '#retrieve_location_info' do
+      response = subject.retrieve_location_info('denver,co')
 
       expect(response).to be_a(Hash)
-      expect(response[:lat]).to eq(39.7392358)
-      expect(response[:lng]).to eq(-104.990251)
+      expect(response[:formatted_address]).to eq('Denver, CO, USA')
+      expect(response[:geometry][:location][:lat]).to eq(39.7392358)
+      expect(response[:geometry][:location][:lng]).to eq(-104.990251)
     end
   end
 end


### PR DESCRIPTION
This PR adds a location_address to the LocationForecast.

- GoogleMapsService retrieve_latlong method has been converted to retrieve_location_info
- ForecastFacade now leverages GoogleMapsService to retreive both the latlong and formatted address of a location
- LocationForecast has an additional attribute location_address
- ForecastSerializer now sends a key :location pointing to the location address
- Updates specs to match