### PR TITLE
Forecast Facade Refactor

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::BackgroundsController < ApplicationController
   def show
-    facade = ForecastFacade.new(location_params)
+    facade = BackgroundFacade.new(location_params)
     render json: BackgroundSerializer.serialize(facade.location_album)
   end
 

--- a/app/controllers/api/v1/road_trips_controller.rb
+++ b/app/controllers/api/v1/road_trips_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::RoadTripsController < ApplicationController
     user = User.find_by(api_key: params[:api_key])
 
     if user
-      facade = ForecastFacade.new(road_trip_params)
+      facade = RoadTripFacade.new(road_trip_params)
       render json: RoadTripForecastSerializer.serialize(facade.road_trip_forecast)
     else
       render json: { error: 'Unauthorized API key' }, status: 401

--- a/app/facades/background_facade.rb
+++ b/app/facades/background_facade.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class BackgroundFacade
+  def initialize(location_params)
+    @location_params = location_params
+  end
+
+  def location_album
+    LocationAlbum.new(images)
+  end
+
+  private
+
+  attr_reader :location_params
+
+  def images
+    flickr_service.retrieve_images
+  end
+
+  def flickr_service
+    FlickrService.new(flickr_lat, flickr_long)
+  end
+
+  def flickr_lat
+    google_maps_facade.location_latlong[:lat].to_s
+  end
+
+  def flickr_long
+    google_maps_facade.location_latlong[:lng].to_s
+  end
+
+  def google_maps_facade
+    @google_maps_facade ||= GoogleMapsFacade.new(location_params)
+  end
+end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -1,72 +1,39 @@
 # frozen_string_literal: true
 
 class ForecastFacade
-  def initialize(params)
-    @params = params
-  end
-
-  def location_album
-    @location_album ||= LocationAlbum.new(images)
+  def initialize(location_params)
+    @location_params = location_params
   end
 
   def location_forecast
-    @location_forecast ||= LocationForecast.new(location_address, forecast)
-  end
-
-  def road_trip_forecast
-    @road_trip_forecast ||= RoadTripForecast.new(road_trip, forecast)
+    LocationForecast.new(location_address, forecast)
   end
 
   private
 
-  attr_reader :params
-
-  def images
-    @images ||= flickr_service.retrieve_images
-  end
-
-  def flickr_service
-    @flickr_service ||= FlickrService.new(flickr_lat, flickr_long)
-  end
-
-  def flickr_lat
-    location_latlong[:lat].to_s
-  end
-
-  def flickr_long
-    location_latlong[:lng].to_s
-  end
+  attr_reader :location_params
 
   def forecast
     @forecast ||= darksky_service.retrieve_forecast(darksky_latlong)
   end
 
   def darksky_service
-    @darksky_service ||= DarkskyService.new
+    DarkskyService.new
   end
 
   def darksky_latlong
     location_latlong[:lat].to_s + ',' + location_latlong[:lng].to_s
   end
 
-  def location_latlong
-    params[:location] = params[:destination] if params[:destination]
-    location[:geometry][:location]
-  end
-
   def location_address
-    location[:formatted_address]
+    google_maps_facade.location_address
   end
 
-  def location
-    @location ||= google_maps_service.retrieve_location(params)
+  def location_latlong
+    @location_latlong ||= google_maps_facade.location_latlong
   end
 
-  def road_trip
-    @road_trip ||= google_maps_service.retrieve_road_trip(params)
-  end
-
-  def google_maps_service
-    @google_maps_service ||= GoogleMapsService.new
+  def google_maps_facade
+    @google_maps_facade ||= GoogleMapsFacade.new(location_params)
   end
 end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -14,11 +14,11 @@ class ForecastFacade
   attr_reader :location_params
 
   def forecast
-    darksky_service.retrieve_forecast(darksky_latlong)
+    darksky_service.retrieve_forecast
   end
 
   def darksky_service
-    DarkskyService.new
+    DarkskyService.new(darksky_latlong)
   end
 
   def darksky_latlong

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -14,7 +14,7 @@ class ForecastFacade
   attr_reader :location_params
 
   def forecast
-    @forecast ||= darksky_service.retrieve_forecast(darksky_latlong)
+    darksky_service.retrieve_forecast(darksky_latlong)
   end
 
   def darksky_service

--- a/app/facades/google_maps_facade.rb
+++ b/app/facades/google_maps_facade.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class GoogleMapsFacade
+  def initialize(params)
+    @params = params
+  end
+
+  def location_address
+    location[:formatted_address]
+  end
+
+  def location_latlong
+    params[:location] = params[:destination] if params[:destination]
+    location[:geometry][:location]
+  end
+
+  def road_trip
+    google_maps_service.retrieve_road_trip(params)
+  end
+
+  private
+
+  attr_reader :params
+
+  def location
+    @location ||= google_maps_service.retrieve_location(params)
+  end
+
+  def google_maps_service
+    @google_maps_service ||= GoogleMapsService.new
+  end
+end

--- a/app/facades/google_maps_facade.rb
+++ b/app/facades/google_maps_facade.rb
@@ -15,7 +15,7 @@ class GoogleMapsFacade
   end
 
   def road_trip
-    google_maps_service.retrieve_road_trip(params)
+    google_maps_service.retrieve_road_trip
   end
 
   private
@@ -23,10 +23,10 @@ class GoogleMapsFacade
   attr_reader :params
 
   def location
-    @location ||= google_maps_service.retrieve_location(params)
+    @location ||= google_maps_service.retrieve_location
   end
 
   def google_maps_service
-    @google_maps_service ||= GoogleMapsService.new
+    @google_maps_service ||= GoogleMapsService.new(params)
   end
 end

--- a/app/facades/road_trip_facade.rb
+++ b/app/facades/road_trip_facade.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class RoadTripFacade
+  def initialize(road_trip_params)
+    @road_trip_params = road_trip_params
+  end
+
+  def road_trip_forecast
+    RoadTripForecast.new(road_trip, forecast)
+  end
+
+  private
+
+  attr_reader :road_trip_params
+
+  def forecast
+    darksky_service.retrieve_forecast(darksky_latlong)
+  end
+
+  def darksky_service
+    DarkskyService.new
+  end
+
+  def darksky_latlong
+    location_latlong[:lat].to_s + ',' + location_latlong[:lng].to_s
+  end
+
+  def location_latlong
+    @location_latlong ||= google_maps_facade.location_latlong
+  end
+
+  def road_trip
+    google_maps_facade.road_trip
+  end
+
+  def google_maps_facade
+    @google_maps_facade ||= GoogleMapsFacade.new(road_trip_params)
+  end
+end

--- a/app/facades/road_trip_facade.rb
+++ b/app/facades/road_trip_facade.rb
@@ -14,11 +14,11 @@ class RoadTripFacade
   attr_reader :road_trip_params
 
   def forecast
-    darksky_service.retrieve_forecast(darksky_latlong)
+    darksky_service.retrieve_forecast
   end
 
   def darksky_service
-    DarkskyService.new
+    DarkskyService.new(darksky_latlong)
   end
 
   def darksky_latlong

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,11 @@ class User < ApplicationRecord
 
   has_secure_password
 
-  after_create :update_api_key
+  before_create :create_api_key
 
   private
 
-  def update_api_key
-    update(api_key: SecureRandom.hex)
+  def create_api_key
+    self.api_key = SecureRandom.hex
   end
 end

--- a/app/services/darksky_service.rb
+++ b/app/services/darksky_service.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class DarkskyService
-  def retrieve_forecast(latlong)
+  def initialize(latlong)
+    @latlong = latlong
+  end
+
+  def retrieve_forecast
     parse_response(latlong.to_s)
   end
 
   private
+
+  attr_reader :latlong
 
   def parse_response(url, params = {})
     response = connection.get(url, params)

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
 class GoogleMapsService
-  def retrieve_location(location_params)
-    parse_response('geocode/json', address: location_params[:location])[:results][0]
+  def initialize(params)
+    @params = params
   end
 
-  def retrieve_road_trip(road_trip_params)
-    parse_response('directions/json', origin: road_trip_params[:origin], destination: road_trip_params[:destination])[:routes][0][:legs][0]
+  def retrieve_location
+    parse_response('geocode/json', address: params[:location])[:results][0]
+  end
+
+  def retrieve_road_trip
+    parse_response('directions/json', origin: params[:origin], destination: params[:destination])[:routes][0][:legs][0]
   end
 
   private
+
+  attr_reader :params
 
   def parse_response(url, params = {})
     response = connection.get(url, params)

--- a/spec/services/darksky_service_spec.rb
+++ b/spec/services/darksky_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DarkskyService do
   describe 'instance methods' do
     it '#retrieve_forecast' do
       darksky_service = DarkskyService.new('39.7392358,-104.990251')
-      
+
       response = darksky_service.retrieve_forecast
 
       expect(response).to be_a(Hash)

--- a/spec/services/darksky_service_spec.rb
+++ b/spec/services/darksky_service_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe DarkskyService do
   describe 'instance methods' do
     it '#retrieve_forecast' do
-      response = subject.retrieve_forecast('39.7392358,-104.990251')
+      darksky_service = DarkskyService.new('39.7392358,-104.990251')
+      
+      response = darksky_service.retrieve_forecast
 
       expect(response).to be_a(Hash)
 

--- a/spec/services/google_maps_service_spec.rb
+++ b/spec/services/google_maps_service_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe GoogleMapsService do
     it '#retrieve_location' do
       location_params = { location: 'denver,co' }
 
-      response = subject.retrieve_location(location_params)
+      google_maps_service = GoogleMapsService.new(location_params)
+
+      response = google_maps_service.retrieve_location
 
       expect(response).to be_a(Hash)
       expect(response[:formatted_address]).to eq('Denver, CO, USA')
@@ -19,7 +21,9 @@ RSpec.describe GoogleMapsService do
       road_trip_params = { origin: 'denver,co',
                            destination: 'pueblo,co' }
 
-      response = subject.retrieve_road_trip(road_trip_params)
+      google_maps_service = GoogleMapsService.new(road_trip_params)
+
+      response = google_maps_service.retrieve_road_trip
 
       expect(response).to be_a(Hash)
       expect(response).to have_key(:duration)


### PR DESCRIPTION
This PR breaks up the monopoly that was the ForecastFacade.  Facades have been created for each API call, which all leverage a GoogleMapsFacade to pull the necessary information from the GoogleMapsService.